### PR TITLE
feat: implement project management API with durable object

### DIFF
--- a/.agents/project_tasks.json
+++ b/.agents/project_tasks.json
@@ -1,0 +1,127 @@
+{
+  "projectName": "AI Collaboration Platform",
+  "vision": "Transform the 'ai-collaboration' repository into a comprehensive AI orchestration platform where multiple AI agents can collaborate in real-time, sharing context and coordinating work across different coding tasks.",
+  "phases": [
+    {
+      "phaseName": "Phase 1: Foundation",
+      "status": "Completed",
+      "timeline": "Week 1",
+      "tasks": [
+        {
+          "taskName": "Setup Basic Worker Structure",
+          "status": "Completed",
+          "success_criteria": "A Cloudflare Worker is deployed and responds to basic HTTP requests, serving as the entry point for the platform.",
+          "subtasks": [
+            {
+              "subtaskName": "Initialize a new Cloudflare Worker project",
+              "status": "Completed",
+              "notes": "Existing project already initialized"
+            },
+            {
+              "subtaskName": "Configure `wrangler.toml` for development and production environments",
+              "status": "Completed",
+              "notes": "wrangler.toml updated with DO and D1 bindings"
+            },
+            {
+              "subtaskName": "Implement a basic 'hello world' fetch handler in `src/index.ts`",
+              "status": "Completed",
+              "notes": "Health and metrics endpoints respond"
+            }
+          ],
+          "notes": "Worker skeleton verified"
+        },
+        {
+          "taskName": "Add Project Management API",
+          "status": "Completed",
+          "success_criteria": "REST endpoints for creating, reading, updating, and deleting projects are functional and persist data to D1.",
+          "subtasks": [
+            {
+              "subtaskName": "Define project-related routes in `src/routes/projects.ts`",
+              "status": "Completed",
+              "notes": "Route handler implemented"
+            },
+            {
+              "subtaskName": "Implement CRUD logic for projects",
+              "status": "Completed",
+              "notes": "DatabaseService handles operations"
+            },
+            {
+              "subtaskName": "Connect the API to the D1 database service",
+              "status": "Completed",
+              "notes": "D1 binding and service integrated"
+            }
+          ],
+          "notes": "API and tests added; ensured DB timestamp and status mappings"
+        },
+        {
+          "taskName": "Implement Basic D1 Schema",
+          "status": "Completed",
+          "success_criteria": "A `database.sql` schema file exists and can be used to set up the D1 database with tables for projects, agents, and tasks.",
+          "subtasks": [
+            {
+              "subtaskName": "Create `schemas/database.sql`",
+              "status": "Completed",
+              "notes": "Schema file created"
+            },
+            {
+              "subtaskName": "Define tables for `projects`, `agents`, and `tasks`",
+              "status": "Completed",
+              "notes": "Tables defined in schema"
+            },
+            {
+              "subtaskName": "Write D1 client logic in `src/services/DatabaseService.ts`",
+              "status": "Completed",
+              "notes": "Service exposes CRUD methods"
+            }
+          ],
+          "notes": "Schema applied via Wrangler commands"
+        },
+        {
+          "taskName": "Create Durable Objects for State Management",
+          "status": "Completed",
+          "success_criteria": "The `ProjectCoordinator` Durable Object can be instantiated and maintains the state for a single project.",
+          "subtasks": [
+            {
+              "subtaskName": "Implement the `ProjectCoordinator.ts` Durable Object class",
+              "status": "Completed",
+              "notes": "Full agent/task/message state management with persistence and broadcast"
+            },
+            {
+              "subtaskName": "Define the `ProjectState` interface",
+              "status": "Completed",
+              "notes": "Interface included in DO file"
+            },
+            {
+              "subtaskName": "Bind the Durable Object in `wrangler.toml`",
+              "status": "Completed",
+              "notes": "Binding added with migration"
+            }
+          ],
+          "notes": "DO accessible at /api/projects/{id}/state"
+        }
+      ],
+      "notes": "Foundation layer ready"
+    },
+    {
+      "phaseName": "Phase 2: Agent Coordination",
+      "status": "Not Started",
+      "timeline": "Week 2",
+      "tasks": [],
+      "notes": "Pending implementation"
+    },
+    {
+      "phaseName": "Phase 3: MCP Integration",
+      "status": "Not Started",
+      "timeline": "Week 3",
+      "tasks": [],
+      "notes": "Pending implementation"
+    },
+    {
+      "phaseName": "Phase 4: AI Enhancement",
+      "status": "Not Started",
+      "timeline": "Week 4",
+      "tasks": [],
+      "notes": "Pending implementation"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AI Collaboration Worker
 
-This project provides a Cloudflare Worker that acts as a lightweight MCP tool for AI agents. It exposes basic monitoring routes (`/health` and `/metrics`) and a workflow demo using Cloudflare Workflows and Durable Objects.
+This project provides a Cloudflare Worker that acts as a lightweight **Model Context Protocol (MCP)** tool for AI agents. It now includes a project management API backed by Cloudflare D1 and a `ProjectCoordinator` Durable Object for per-project state. Monitoring routes (`/health` and `/metrics`), a workflow demo, and an `/mcp` endpoint for simple MCP messages like `ping` remain available.
 
 ## Deployment
 
@@ -12,10 +12,16 @@ This project provides a Cloudflare Worker that acts as a lightweight MCP tool fo
    ```bash
    npx wrangler login
    ```
-3. Deploy the worker
+3. Create the D1 database (only once)
+   ```bash
+   npx wrangler d1 create ai-collaboration-db
+   npx wrangler d1 execute ai-collaboration-db --file=./schemas/database.sql
+   ```
+4. Deploy the worker
    ```bash
    npm run deploy
    ```
+   The `wrangler.toml` file configures Durable Objects and other bindings required by the worker. Adjust it as needed for your account.
 
 ## Development
 
@@ -31,12 +37,11 @@ npm run lint
 
 ## Testing
 
-Unit tests are executed with [Vitest](https://vitest.dev/).
+Unit tests are executed with [Vitest](https://vitest.dev/):
 ```bash
 npm test
 ```
-
-The tests include simple checks for the `/health` and `/metrics` endpoints.
+Tests cover basic MCP interactions and project CRUD endpoints.
 
 ## License
 

--- a/schemas/database.sql
+++ b/schemas/database.sql
@@ -1,0 +1,28 @@
+CREATE TABLE IF NOT EXISTS projects (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  description TEXT,
+  status TEXT DEFAULT 'planning',
+  created_at INTEGER DEFAULT (strftime('%s','now')),
+  updated_at INTEGER DEFAULT (strftime('%s','now'))
+);
+
+CREATE TABLE IF NOT EXISTS agents (
+  id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  role TEXT,
+  created_at INTEGER DEFAULT (strftime('%s','now')),
+  updated_at INTEGER DEFAULT (strftime('%s','now')),
+  FOREIGN KEY(project_id) REFERENCES projects(id)
+);
+
+CREATE TABLE IF NOT EXISTS tasks (
+  id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  status TEXT,
+  created_at INTEGER DEFAULT (strftime('%s','now')),
+  updated_at INTEGER DEFAULT (strftime('%s','now')),
+  FOREIGN KEY(project_id) REFERENCES projects(id)
+);

--- a/schemas/database.sql
+++ b/schemas/database.sql
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS agents (
   role TEXT,
   created_at INTEGER DEFAULT (strftime('%s','now')),
   updated_at INTEGER DEFAULT (strftime('%s','now')),
-  FOREIGN KEY(project_id) REFERENCES projects(id)
+  FOREIGN KEY(project_id) REFERENCES projects(id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS tasks (

--- a/schemas/database.sql
+++ b/schemas/database.sql
@@ -24,5 +24,5 @@ CREATE TABLE IF NOT EXISTS tasks (
   status TEXT,
   created_at INTEGER DEFAULT (strftime('%s','now')),
   updated_at INTEGER DEFAULT (strftime('%s','now')),
-  FOREIGN KEY(project_id) REFERENCES projects(id)
+  FOREIGN KEY(project_id) REFERENCES projects(id) ON DELETE CASCADE
 );

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -1,0 +1,149 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "AI Collaboration Platform API",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/api/projects": {
+      "get": {
+        "summary": "List projects",
+        "responses": {
+          "200": {
+            "description": "Array of Project",
+            "content": {
+              "application/json": {
+                "schema": {"type": "array", "items": {"$ref": "#/components/schemas/Project"}}
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create project",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {"schema": {"$ref": "#/components/schemas/Project"}}
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created project",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Project"}}}
+          }
+        }
+      }
+    },
+    "/api/projects/{id}": {
+      "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
+      "get": {
+        "summary": "Get project by id",
+        "responses": {"200": {"description": "Project", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Project"}}}}, "404": {"description": "Not found"}}
+      },
+      "put": {
+        "summary": "Update project",
+        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Project"}}}},
+        "responses": {"204": {"description": "Updated"}}
+      },
+      "delete": {"summary": "Delete project", "responses": {"204": {"description": "Deleted"}}}
+    },
+    "/api/projects/{id}/agents": {
+      "get": {
+        "summary": "List agents",
+        "responses": {"200": {"description": "Array of Agent", "content": {"application/json": {"schema": {"type": "array", "items": {"$ref": "#/components/schemas/Agent"}}}}}}
+      },
+      "post": {
+        "summary": "Register agent",
+        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Agent"}}}},
+        "responses": {"200": {"description": "Registered agent", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Agent"}}}}}
+      }
+    },
+    "/api/projects/{id}/tasks": {
+      "get": {
+        "summary": "List tasks",
+        "parameters": [
+          {"name": "status", "in": "query", "schema": {"type": "string"}},
+          {"name": "tags", "in": "query", "schema": {"type": "string", "description": "Comma separated"}}
+        ],
+        "responses": {"200": {"description": "Array of Task", "content": {"application/json": {"schema": {"type": "array", "items": {"$ref": "#/components/schemas/Task"}}}}}}
+      },
+      "post": {
+        "summary": "Create task",
+        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Task"}}}},
+        "responses": {"200": {"description": "Created task", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Task"}}}}}
+      }
+    },
+    "/api/projects/{id}/messages": {
+      "get": {
+        "summary": "List messages",
+        "parameters": [
+          {"name": "type", "in": "query", "schema": {"type": "string"}},
+          {"name": "limit", "in": "query", "schema": {"type": "integer"}}
+        ],
+        "responses": {"200": {"description": "Array of Message", "content": {"application/json": {"schema": {"type": "array", "items": {"$ref": "#/components/schemas/Message"}}}}}}
+      },
+      "post": {
+        "summary": "Send message",
+        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Message"}}}},
+        "responses": {"200": {"description": "Ack"}}
+      }
+    },
+    "/mcp": {
+      "post": {"summary": "Handle MCP requests", "responses": {"200": {"description": "MCP response"}}}
+    }
+  },
+  "components": {
+    "schemas": {
+      "Project": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string"},
+          "name": {"type": "string"},
+          "description": {"type": "string"},
+          "status": {"type": "string", "enum": ["planning", "active", "paused", "completed", "archived"]},
+          "createdAt": {"type": "integer"},
+          "updatedAt": {"type": "integer"}
+        },
+        "required": ["id", "name", "status", "createdAt", "updatedAt"]
+      },
+      "Agent": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string"},
+          "name": {"type": "string"},
+          "role": {"type": "string"},
+          "model": {"type": "string"},
+          "status": {"type": "string"},
+          "lastSeen": {"type": "integer"}
+        },
+        "required": ["id", "name", "role", "model", "status", "lastSeen"]
+      },
+      "Task": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string"},
+          "title": {"type": "string"},
+          "description": {"type": "string"},
+          "status": {"type": "string"},
+          "priority": {"type": "string"},
+          "tags": {"type": "array", "items": {"type": "string"}},
+          "createdAt": {"type": "integer"},
+          "updatedAt": {"type": "integer"}
+        },
+        "required": ["id", "title", "status", "priority", "createdAt", "updatedAt"]
+      },
+      "Message": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string"},
+          "agentId": {"type": "string"},
+          "type": {"type": "string"},
+          "content": {"type": "string"},
+          "timestamp": {"type": "integer"}
+        },
+        "required": ["id", "agentId", "type", "content", "timestamp"]
+      }
+    }
+  }
+}

--- a/src/durable-objects/ProjectCoordinator.ts
+++ b/src/durable-objects/ProjectCoordinator.ts
@@ -1,0 +1,691 @@
+import { DurableObject } from "cloudflare:workers";
+
+export interface Agent {
+  id: string;
+  name: string;
+  role:
+    | "frontend"
+    | "backend"
+    | "fullstack"
+    | "devops"
+    | "designer"
+    | "tester";
+  model: "chatgpt" | "claude" | "gemini" | "cursor" | "copilot" | "custom";
+  status: "active" | "idle" | "working" | "blocked" | "offline";
+  currentTask?: string;
+  websocket?: WebSocket;
+  lastSeen: number;
+  capabilities: string[];
+  preferences: Record<string, any>;
+}
+
+export interface Task {
+  id: string;
+  title: string;
+  description: string;
+  assignedTo?: string;
+  status: "todo" | "in-progress" | "review" | "blocked" | "completed";
+  priority: "low" | "medium" | "high" | "urgent";
+  dependencies: string[];
+  estimatedHours?: number;
+  actualHours?: number;
+  createdAt: number;
+  updatedAt: number;
+  tags: string[];
+}
+
+export interface Message {
+  id: string;
+  agentId: string;
+  type: "chat" | "status" | "code" | "file" | "system";
+  content: string;
+  metadata?: Record<string, any>;
+  timestamp: number;
+}
+
+export interface ProjectSettings {
+  maxAgents: number;
+  allowCrossAgentChat: boolean;
+  autoSaveInterval: number;
+  notificationSettings: {
+    onTaskComplete: boolean;
+    onAgentJoin: boolean;
+    onBlocker: boolean;
+  };
+  aiAssistance: {
+    enabled: boolean;
+    autoSuggestions: boolean;
+    codeReview: boolean;
+  };
+}
+
+export interface ProjectState {
+  id: string;
+  name: string;
+  description: string;
+  status: "planning" | "active" | "paused" | "completed" | "archived";
+  agents: Map<string, Agent>;
+  tasks: Map<string, Task>;
+  files: string[];
+  context: Record<string, any>;
+  messageHistory: Message[];
+  createdAt: number;
+  updatedAt: number;
+  settings: ProjectSettings;
+}
+
+interface Env {}
+
+/**
+ * Durable Object that maintains collaborative project state including agents,
+ * tasks and message history. All `/api/projects/{id}/*` routes are forwarded
+ * here with the sub-path representing the resource.
+ */
+export class ProjectCoordinator extends DurableObject {
+  private objectState: DurableObjectState;
+  private state: ProjectState;
+  private websockets: Set<WebSocket> = new Set();
+
+  constructor(state: DurableObjectState, env: Env) {
+    super(state, env);
+    this.objectState = state;
+    state.blockConcurrencyWhile(async () => {
+      const stored = await state.storage.get<any>("state");
+      if (stored) {
+        this.state = {
+          ...stored,
+          agents: new Map(stored.agents || []),
+          tasks: new Map(stored.tasks || []),
+        } as ProjectState;
+      } else {
+        this.state = {
+          id: "",
+          name: "",
+          description: "",
+          status: "planning",
+          agents: new Map(),
+          tasks: new Map(),
+          files: [],
+          context: {},
+          messageHistory: [],
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+          settings: {
+            maxAgents: 10,
+            allowCrossAgentChat: true,
+            autoSaveInterval: 30000,
+            notificationSettings: {
+              onTaskComplete: true,
+              onAgentJoin: true,
+              onBlocker: true,
+            },
+            aiAssistance: {
+              enabled: true,
+              autoSuggestions: true,
+              codeReview: true,
+            },
+          },
+        };
+      }
+    });
+  }
+
+  /**
+   * Routes HTTP requests and WebSocket upgrades for project coordination.
+   *
+   * Supported REST endpoints relative to `/api/projects/{id}`:
+   * - `GET /state` – full serialized project state.
+   * - `GET /agents` – list agents.
+   * - `GET /tasks?status=&tags=` – list tasks filtered by status or tags.
+   * - `GET /messages?type=&limit=` – list messages with optional type filter
+   *   and limit.
+   * - `GET /analytics` – project analytics summary.
+   * - `POST /initialize` – initialize project state.
+   * - `POST /agents` – register an agent.
+   * - `POST /tasks` – create a task.
+   * - `POST /messages` – append a message.
+   * - `PUT /agents/:id` – update agent fields.
+   * - `PUT /tasks/:id` – update a task.
+   * - `PUT /context` – merge into project context.
+   * - `DELETE /agents/:id` – remove an agent.
+   * - `DELETE /tasks/:id` – delete a task.
+   */
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (request.headers.get("Upgrade") === "websocket") {
+      return this.handleWebSocket(request);
+    }
+
+    switch (request.method) {
+      case "GET":
+        return this.handleGet(url.pathname, url.searchParams);
+      case "POST":
+        return this.handlePost(url.pathname, request);
+      case "PUT":
+        return this.handlePut(url.pathname, request);
+      case "DELETE":
+        return this.handleDelete(url.pathname);
+      default:
+        return new Response("Method not allowed", { status: 405 });
+    }
+  }
+
+  /**
+    * Upgrades the request to a WebSocket connection for real-time updates.
+    * Clients receive broadcast messages for project events and may send JSON
+    * commands such as `agent.register` or `task.update`.
+    */
+  private async handleWebSocket(request: Request): Promise<Response> {
+    const pair = new WebSocketPair();
+    const [client, server] = Object.values(pair) as [WebSocket, WebSocket];
+    this.websockets.add(server);
+    server.accept();
+
+    server.addEventListener("message", async (event) => {
+      try {
+        const message = JSON.parse(event.data as string);
+        await this.handleWebSocketMessage(message, server);
+      } catch {
+        server.send(
+          JSON.stringify({ type: "error", message: "Invalid message format" })
+        );
+      }
+    });
+
+    server.addEventListener("close", () => {
+      this.websockets.delete(server);
+    });
+
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  /**
+   * Processes incoming WebSocket messages. Supported `type` values:
+   * `agent.register`, `agent.update`, `task.create`, `task.update`,
+   * `message.send`, and `context.update`.
+   */
+  private async handleWebSocketMessage(message: any, ws: WebSocket) {
+    switch (message.type) {
+      case "agent.register":
+        await this.registerAgent(message.agent, ws);
+        break;
+      case "agent.update":
+        await this.updateAgent(message.agentId, message.updates);
+        break;
+      case "task.create":
+        await this.createTask(message.task);
+        break;
+      case "task.update":
+        await this.updateTask(message.taskId, message.updates);
+        break;
+      case "message.send":
+        await this.sendMessage(message.message);
+        break;
+      case "context.update":
+        await this.updateContext(message.context);
+        break;
+      default:
+        ws.send(
+          JSON.stringify({ type: "error", message: "Unknown message type" })
+        );
+    }
+  }
+
+  /**
+   * Responds to HTTP `GET` requests for project resources.
+   *
+   * - `/state` – returns `ProjectState`.
+   * - `/agents` – returns array of `Agent`.
+   * - `/tasks` – returns tasks filtered by optional `status` and comma-separated
+   *   `tags` query parameters.
+   * - `/messages` – returns messages filtered by optional `type` and limited by
+   *   `limit` query parameter (most recent first).
+   * - `/analytics` – derived statistics about agents and tasks.
+   */
+  private async handleGet(
+    path: string,
+    search: URLSearchParams,
+  ): Promise<Response> {
+    if (path === "/state") {
+      return this.jsonResponse(this.serializeState());
+    }
+    if (path === "/agents") {
+      return this.jsonResponse(Array.from(this.state.agents.values()));
+    }
+    if (path === "/tasks") {
+      let tasks = Array.from(this.state.tasks.values());
+      const status = search.get("status");
+      if (status) {
+        tasks = tasks.filter((t) => t.status === status);
+      }
+      const tags = search.get("tags");
+      if (tags) {
+        const tagSet = new Set(tags.split(","));
+        tasks = tasks.filter((t) =>
+          t.tags.some((tag) => tagSet.has(tag)),
+        );
+      }
+      return this.jsonResponse(tasks);
+    }
+    if (path === "/messages") {
+      let messages = this.state.messageHistory;
+      const type = search.get("type");
+      if (type) {
+        messages = messages.filter((m) => m.type === type);
+      }
+      const limit = parseInt(search.get("limit") || "", 10);
+      if (!Number.isNaN(limit)) {
+        messages = messages.slice(-limit);
+      }
+      return this.jsonResponse(messages);
+    }
+    if (path === "/analytics") {
+      return this.jsonResponse(await this.generateAnalytics());
+    }
+    return new Response("Not found", { status: 404 });
+  }
+
+  /**
+   * Handles creation endpoints via HTTP `POST`.
+   *
+   * - `/initialize` – body: `Partial<ProjectState>` to seed a new project.
+   * - `/agents` – body: `Partial<Agent>` to register an agent.
+   * - `/tasks` – body: `Partial<Task>` to create a task.
+   * - `/messages` – body: `Partial<Message>` to append a message.
+   */
+  private async handlePost(path: string, request: Request): Promise<Response> {
+    const data = await request.json();
+    if (path === "/initialize") {
+      await this.initializeProject(data);
+      return this.jsonResponse({ success: true });
+    }
+    if (path === "/agents") {
+      const agent = await this.registerAgent(data);
+      return this.jsonResponse(agent);
+    }
+    if (path === "/tasks") {
+      const task = await this.createTask(data);
+      return this.jsonResponse(task);
+    }
+    if (path === "/messages") {
+      await this.sendMessage(data);
+      return this.jsonResponse({ success: true });
+    }
+    return new Response("Not found", { status: 404 });
+  }
+
+  /**
+   * Handles update endpoints via HTTP `PUT`.
+   *
+   * - `/agents/:id` – body: `Partial<Agent>` fields to update.
+   * - `/tasks/:id` – body: `Partial<Task>` fields to update.
+   * - `/context` – body: object merged into `state.context`.
+   */
+  private async handlePut(path: string, request: Request): Promise<Response> {
+    const data = await request.json();
+    const parts = path.split("/");
+    if (parts[1] === "agents" && parts[2]) {
+      await this.updateAgent(parts[2], data);
+      return this.jsonResponse({ success: true });
+    }
+    if (parts[1] === "tasks" && parts[2]) {
+      await this.updateTask(parts[2], data);
+      return this.jsonResponse({ success: true });
+    }
+    if (path === "/context") {
+      await this.updateContext(data);
+      return this.jsonResponse({ success: true });
+    }
+    return new Response("Not found", { status: 404 });
+  }
+
+  /**
+   * Handles deletion endpoints via HTTP `DELETE`.
+   *
+   * - `/agents/:id` – remove agent.
+   * - `/tasks/:id` – remove task.
+   */
+  private async handleDelete(path: string): Promise<Response> {
+    const parts = path.split("/");
+    if (parts[1] === "agents" && parts[2]) {
+      await this.removeAgent(parts[2]);
+      return this.jsonResponse({ success: true });
+    }
+    if (parts[1] === "tasks" && parts[2]) {
+      await this.deleteTask(parts[2]);
+      return this.jsonResponse({ success: true });
+    }
+    return new Response("Not found", { status: 404 });
+  }
+
+  /**
+   * Initializes project state from a partial payload. Invoked through
+   * `POST /initialize`.
+   */
+  private async initializeProject(data: Partial<ProjectState>) {
+    this.state = {
+      ...this.state,
+      ...data,
+      id: data.id || crypto.randomUUID(),
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+    await this.persistState();
+    await this.broadcastToAll({
+      type: "project.initialized",
+      project: this.serializeState(),
+    });
+  }
+
+  /**
+   * Registers an agent via `POST /agents` or WebSocket `agent.register`.
+   * Accepts partial `Agent` data and optionally the initiating socket which
+   * is stored for future broadcasts.
+   */
+  private async registerAgent(
+    agentData: Partial<Agent>,
+    websocket?: WebSocket
+  ): Promise<Agent> {
+    const agent: Agent = {
+      id: agentData.id || crypto.randomUUID(),
+      name: agentData.name || "Unknown Agent",
+      role: agentData.role || "fullstack",
+      model: agentData.model || "custom",
+      status: "active",
+      lastSeen: Date.now(),
+      capabilities: agentData.capabilities || [],
+      preferences: agentData.preferences || {},
+      currentTask: agentData.currentTask,
+      websocket,
+    };
+    this.state.agents.set(agent.id, agent);
+    this.state.updatedAt = Date.now();
+    await this.persistState();
+    await this.broadcastToAll({
+      type: "agent.joined",
+      agent: this.serializeAgent(agent),
+    });
+    if (websocket) {
+      websocket.send(
+        JSON.stringify({
+          type: "welcome",
+          projectState: this.serializeState(),
+          agentId: agent.id,
+        })
+      );
+    }
+    return agent;
+  }
+
+  /**
+   * Updates an existing agent's fields. Invoked through
+   * `PUT /agents/:id` or WebSocket `agent.update`.
+   */
+  private async updateAgent(agentId: string, updates: Partial<Agent>) {
+    const agent = this.state.agents.get(agentId);
+    if (!agent) throw new Error("Agent not found");
+    Object.assign(agent, updates, { lastSeen: Date.now() });
+    this.state.updatedAt = Date.now();
+    await this.persistState();
+    await this.broadcastToAll({
+      type: "agent.updated",
+      agentId,
+      agent: this.serializeAgent(agent),
+    });
+  }
+
+  /**
+   * Removes an agent from the project. Triggered via
+   * `DELETE /agents/:id`.
+   */
+  private async removeAgent(agentId: string) {
+    const agent = this.state.agents.get(agentId);
+    if (!agent) return;
+    this.state.agents.delete(agentId);
+    this.state.updatedAt = Date.now();
+    await this.persistState();
+    await this.broadcastToAll({ type: "agent.left", agentId });
+  }
+
+  /**
+   * Creates a new task using fields supplied via `POST /tasks` or WebSocket
+   * `task.create`.
+   */
+  private async createTask(taskData: Partial<Task>): Promise<Task> {
+    const task: Task = {
+      id: taskData.id || crypto.randomUUID(),
+      title: taskData.title || "Untitled Task",
+      description: taskData.description || "",
+      status: taskData.status || "todo",
+      priority: taskData.priority || "medium",
+      dependencies: taskData.dependencies || [],
+      tags: taskData.tags || [],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      assignedTo: taskData.assignedTo,
+      estimatedHours: taskData.estimatedHours,
+      actualHours: taskData.actualHours,
+    };
+    this.state.tasks.set(task.id, task);
+    this.state.updatedAt = Date.now();
+    await this.persistState();
+    await this.broadcastToAll({ type: "task.created", task });
+    return task;
+  }
+
+  /**
+   * Applies updates to an existing task. Triggered via `PUT /tasks/:id` or
+   * WebSocket `task.update`.
+   */
+  private async updateTask(taskId: string, updates: Partial<Task>) {
+    const task = this.state.tasks.get(taskId);
+    if (!task) throw new Error("Task not found");
+    Object.assign(task, updates, { updatedAt: Date.now() });
+    this.state.updatedAt = Date.now();
+    await this.persistState();
+    await this.broadcastToAll({ type: "task.updated", taskId, task });
+    if (updates.status === "completed") {
+      await this.notifyTaskCompletion(task);
+    }
+    if (updates.status === "blocked") {
+      await this.notifyTaskBlocked(task);
+    }
+  }
+
+  /**
+   * Deletes a task from the project. Invoked via `DELETE /tasks/:id`.
+   */
+  private async deleteTask(taskId: string) {
+    this.state.tasks.delete(taskId);
+    this.state.updatedAt = Date.now();
+    await this.persistState();
+    await this.broadcastToAll({ type: "task.deleted", taskId });
+  }
+
+  /**
+   * Appends a message to project history. Called via `POST /messages` or
+   * WebSocket `message.send`. Only the last 1000 messages are retained.
+   */
+  private async sendMessage(messageData: Partial<Message>) {
+    const message: Message = {
+      id: messageData.id || crypto.randomUUID(),
+      agentId: messageData.agentId || "system",
+      type: messageData.type || "chat",
+      content: messageData.content || "",
+      metadata: messageData.metadata,
+      timestamp: Date.now(),
+    };
+    this.state.messageHistory.push(message);
+    if (this.state.messageHistory.length > 1000) {
+      this.state.messageHistory = this.state.messageHistory.slice(-1000);
+    }
+    this.state.updatedAt = Date.now();
+    await this.persistState();
+    await this.broadcastToAll({ type: "message.new", message });
+  }
+
+  /**
+   * Merges the supplied object into shared project context. Invoked via
+   * `PUT /context` or WebSocket `context.update`.
+   */
+  private async updateContext(contextUpdates: Record<string, any>) {
+    Object.assign(this.state.context, contextUpdates);
+    this.state.updatedAt = Date.now();
+    await this.persistState();
+    await this.broadcastToAll({
+      type: "context.updated",
+      context: this.state.context,
+    });
+  }
+
+  /**
+   * Broadcasts a JSON-serializable message to all connected WebSocket
+   * clients. Broken sockets are cleaned up automatically.
+   */
+  private async broadcastToAll(message: any) {
+    const str = JSON.stringify(message);
+    for (const ws of this.websockets) {
+      try {
+        ws.send(str);
+      } catch {
+        this.websockets.delete(ws);
+      }
+    }
+  }
+
+  /**
+   * Persists the current `ProjectState` to Durable Object storage.
+   */
+  private async persistState() {
+    const serializable = {
+      ...this.state,
+      agents: Array.from(this.state.agents.entries()),
+      tasks: Array.from(this.state.tasks.entries()),
+    } as any;
+    await this.objectState.storage.put("state", serializable);
+  }
+
+  /**
+   * Produces a JSON-serializable representation of the project state.
+   * WebSocket references are stripped from agents.
+   */
+  private serializeState() {
+    return {
+      ...this.state,
+      agents: Array.from(this.state.agents.values()).map((a) =>
+        this.serializeAgent(a)
+      ),
+      tasks: Array.from(this.state.tasks.values()),
+    };
+  }
+
+  /**
+   * Serializes an `Agent` by omitting the WebSocket reference, suitable for
+   * storage or API responses.
+   */
+  private serializeAgent(agent: Agent) {
+    const { websocket, ...rest } = agent;
+    return rest;
+  }
+
+  /**
+   * Generates simple aggregate metrics about current agents and tasks.
+   * Returned by `GET /analytics`.
+   */
+  private async generateAnalytics() {
+    const agents = Array.from(this.state.agents.values());
+    const tasks = Array.from(this.state.tasks.values());
+    return {
+      agents: {
+        total: agents.length,
+        active: agents.filter((a) => a.status === "active").length,
+        byRole: agents.reduce((acc, a) => {
+          acc[a.role] = (acc[a.role] || 0) + 1;
+          return acc;
+        }, {} as Record<string, number>),
+        byModel: agents.reduce((acc, a) => {
+          acc[a.model] = (acc[a.model] || 0) + 1;
+          return acc;
+        }, {} as Record<string, number>),
+      },
+      tasks: {
+        total: tasks.length,
+        completed: tasks.filter((t) => t.status === "completed").length,
+        inProgress: tasks.filter((t) => t.status === "in-progress").length,
+        blocked: tasks.filter((t) => t.status === "blocked").length,
+        byPriority: tasks.reduce((acc, t) => {
+          acc[t.priority] = (acc[t.priority] || 0) + 1;
+          return acc;
+        }, {} as Record<string, number>),
+      },
+      productivity: {
+        messagesPerHour: this.calculateMessageRate(),
+        averageTaskTime: this.calculateAverageTaskTime(),
+        completionRate:
+          tasks.length > 0
+            ? tasks.filter((t) => t.status === "completed").length / tasks.length
+            : 0,
+      },
+    };
+  }
+
+  /**
+   * Calculates the number of messages posted in the last hour.
+   */
+  private calculateMessageRate(): number {
+    const hourAgo = Date.now() - 3600000;
+    const recent = this.state.messageHistory.filter((m) => m.timestamp > hourAgo);
+    return recent.length;
+  }
+
+  /**
+   * Computes the average `actualHours` for tasks marked as completed.
+   */
+  private calculateAverageTaskTime(): number {
+    const completed = Array.from(this.state.tasks.values()).filter(
+      (t) => t.status === "completed" && t.actualHours
+    );
+    if (completed.length === 0) return 0;
+    const total = completed.reduce(
+      (sum, t) => sum + (t.actualHours || 0),
+      0
+    );
+    return total / completed.length;
+  }
+
+  /**
+   * Sends a system message announcing task completion when enabled by
+   * notification settings.
+   */
+  private async notifyTaskCompletion(task: Task) {
+    if (!this.state.settings.notificationSettings.onTaskComplete) return;
+    await this.sendMessage({
+      type: "system",
+      content: `🎉 Task "${task.title}" has been completed!`,
+      metadata: { taskId: task.id, event: "task_completed" },
+    });
+  }
+
+  /**
+   * Sends a system message alerting that a task is blocked when enabled by
+   * notification settings.
+   */
+  private async notifyTaskBlocked(task: Task) {
+    if (!this.state.settings.notificationSettings.onBlocker) return;
+    await this.sendMessage({
+      type: "system",
+      content: `⚠️ Task "${task.title}" is blocked and needs attention.`,
+      metadata: { taskId: task.id, event: "task_blocked" },
+    });
+  }
+
+  /**
+   * Helper for returning JSON responses with `Content-Type` header set.
+   */
+  private jsonResponse(data: any): Response {
+    return new Response(JSON.stringify(data, null, 2), {
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,14 +2,17 @@ import {
   WorkflowEntrypoint,
   WorkflowEvent,
   WorkflowStep,
-  WorkflowNamespace
+  WorkflowNamespace,
 } from "cloudflare:workers";
 
 import {
   DurableObject,
   DurableObjectNamespace,
-  Request
-} from '@cloudflare/workers-types';
+  D1Database,
+} from "@cloudflare/workers-types";
+import { handleMCP } from "./mcp";
+import { handleProjects } from "./routes/projects";
+export { ProjectCoordinator } from "./durable-objects/ProjectCoordinator";
 
 declare global {
   const WebSocketPair: any;
@@ -18,11 +21,17 @@ declare global {
 interface Env {
   WEBSOCKET_DO: DurableObjectNamespace;
   WORKFLOW_LIVE: WorkflowNamespace;
+  PROJECT_COORDINATOR: DurableObjectNamespace;
+  AI_COLLABORATION_DB: D1Database;
 }
 
 const startTime = Date.now();
 
-// Simple WebSocket broadcaster
+/**
+ * Durable Object that broadcasts JSON payloads to all connected WebSocket
+ * clients. It is accessed via the Worker at `GET /ws` for upgrades and
+ * accepts `POST` requests with `{id, message}` payloads for broadcasting.
+ */
 export class WebSocketDO implements DurableObject {
   sockets = new Set<WebSocket>();
   env: Env;
@@ -31,66 +40,98 @@ export class WebSocketDO implements DurableObject {
     this.env = env;
   }
 
+  /**
+   * Handles WebSocket upgrades and broadcast posts.
+   *
+   * - `GET /ws` with `Upgrade: websocket` establishes a streaming connection
+   *   that will receive messages sent to this DO.
+   * - `POST /ws` with JSON `{id, message}` broadcasts the payload to all
+   *   connected clients.
+   */
   async fetch(request: Request): Promise<Response> {
-    if (request.headers.get('Upgrade') === 'websocket') {
+    if (request.headers.get("Upgrade") === "websocket") {
       const pair = new WebSocketPair();
       const [client, server] = [pair[0], pair[1]];
       this.sockets.add(server);
       server.accept();
-      server.addEventListener('close', () => this.sockets.delete(server));
+      server.addEventListener("close", () => this.sockets.delete(server));
       return new Response(null, {
         status: 101,
         headers: {
-          'Upgrade': 'websocket',
-          'Connection': 'Upgrade'
+          Upgrade: "websocket",
+          Connection: "Upgrade",
         },
-        webSocket: client
+        webSocket: client,
       });
     }
 
-    const { id, message } = await request.json() as { id: string, message: string };
-    this.sockets.forEach(ws =>
-      ws.readyState === WebSocket.OPEN &&
-      ws.send(JSON.stringify({ id, message, time: new Date().toISOString() }))
+    const { id, message } = (await request.json()) as {
+      id: string;
+      message: string;
+    };
+    this.sockets.forEach(
+      (ws) =>
+        ws.readyState === WebSocket.OPEN &&
+        ws.send(
+          JSON.stringify({ id, message, time: new Date().toISOString() }),
+        ),
     );
-    return new Response('OK');
+    return new Response("OK");
   }
 }
 
-// Simple workflow with logging
+/**
+ * Example workflow that logs progress through a series of timed steps.
+ * The workflow streams log messages through the `WebSocketDO` so clients
+ * can observe execution in real time.
+ */
 export class WorkFlowLive extends WorkflowEntrypoint<Env> {
   private stub = this.env.WEBSOCKET_DO.get(
-    this.env.WEBSOCKET_DO.idFromName('broadcast')
+    this.env.WEBSOCKET_DO.idFromName("broadcast"),
   );
   private q = Promise.resolve();
 
+  /**
+   * Entry point executed by the workflow runtime. Emits log messages over the
+   * broadcast Durable Object while stepping through four sequential actions.
+   */
   async run(event: WorkflowEvent<Record<string, unknown>>, step: WorkflowStep) {
-    const log = (message: string) => this.q = this.q.then(async () => {
-      await this.stub.fetch('http://internal/', {
-        method: 'POST',
-        body: JSON.stringify({
-          id: event.instanceId,
-          message
-        })
-      });
-    });
+    const log = (message: string) =>
+      (this.q = this.q.then(async () => {
+        await this.stub.fetch("http://internal/", {
+          method: "POST",
+          body: JSON.stringify({
+            id: event.instanceId,
+            message,
+          }),
+        });
+      }));
 
     try {
-      await log('Starting workflow...');
+      await log("Starting workflow...");
       await step.sleep("sleep for 1 second", "1 second");
-      await step.do('step1', async () => { await log('Processing step 1...'); return true; });
+      await step.do("step1", async () => {
+        await log("Processing step 1...");
+        return true;
+      });
       await step.sleep("sleep for 1 second", "2 second");
-      await step.do('step2', async () => { await log('Processing step 2...'); return true; });
+      await step.do("step2", async () => {
+        await log("Processing step 2...");
+        return true;
+      });
       await step.sleep("sleep for 1 second", "3 second");
-      await step.do('step3', async () => { await log('Processing step 3...'); return true; });
+      await step.do("step3", async () => {
+        await log("Processing step 3...");
+        return true;
+      });
       await step.sleep("sleep for 1 second", "4 second");
-      await step.do('step4', async () => {
-        await log('Processing step 4...');
-        if (Math.random() > 0.75) throw new Error('Random failure!');
+      await step.do("step4", async () => {
+        await log("Processing step 4...");
+        if (Math.random() > 0.75) throw new Error("Random failure!");
         return true;
       });
       await step.sleep("sleep for 1 second", "1 second");
-      await log('Workflow complete!');
+      await log("Workflow complete!");
       return { success: true };
     } catch (error: any) {
       console.error(error);
@@ -100,30 +141,60 @@ export class WorkFlowLive extends WorkflowEntrypoint<Env> {
   }
 }
 
-// Simple request router
+/**
+ * Main request router for the Worker.
+ *
+ * Routes:
+ * - `GET /health` – returns health status.
+ * - `GET /metrics` – returns uptime.
+ * - `GET /ws` – WebSocket broadcast upgrades handled by `WebSocketDO`.
+ * - `POST /api/workflow` & `GET /api/workflow/:id` – trigger and inspect example workflow runs.
+ * - `/api/projects/{id}/state` – forwards to a `ProjectCoordinator` DO returning project state.
+ * - `/api/projects/{id}/agents|tasks|messages` – forwards subpaths and query strings to the project DO.
+ * - `/api/projects` – project CRUD persisted via D1 handled in `routes/projects`.
+ * - `POST /mcp` – Model Context Protocol endpoint handled in `mcp.ts`.
+ */
 export default {
   async fetch(req: Request, env: Env) {
     const url = new URL(req.url);
-    if (url.pathname === '/health') {
-      return Response.json({ status: 'ok' });
+    if (url.pathname === "/health") {
+      return Response.json({ status: "ok" });
     }
-    if (url.pathname === '/metrics') {
+    if (url.pathname === "/metrics") {
       return Response.json({ uptime: Date.now() - startTime });
     }
-    if (url.pathname === '/ws') {
-      const id = env.WEBSOCKET_DO.idFromName('broadcast');
+    if (url.pathname === "/ws") {
+      const id = env.WEBSOCKET_DO.idFromName("broadcast");
       return env.WEBSOCKET_DO.get(id).fetch(req);
     }
-    if (url.pathname === '/api/workflow') {
+    if (url.pathname === "/api/workflow") {
       const { id } = await env.WORKFLOW_LIVE.create({});
       return Response.json({ id });
     }
-    if (url.pathname.startsWith('/api/workflow/')) {
-      console.log('api/workflow/', url.pathname.split('/').pop());
-      const id = url.pathname.split('/').pop();
+    if (url.pathname.startsWith("/api/workflow/")) {
+      console.log("api/workflow/", url.pathname.split("/").pop());
+      const id = url.pathname.split("/").pop();
       const workflow = await env.WORKFLOW_LIVE.get(id);
       return Response.json({ id, status: await workflow.status() });
     }
-    return new Response('Not found', { status: 404 });
-  }
+    const projectMatch = url.pathname.match(/^\/api\/projects\/([^/]+)\/(.+)$/);
+    if (projectMatch) {
+      const id = projectMatch[1];
+      const subPath = `/${projectMatch[2]}`;
+      const stub = env.PROJECT_COORDINATOR.get(
+        env.PROJECT_COORDINATOR.idFromName(id),
+      );
+      const newUrl = new URL(req.url);
+      newUrl.pathname = subPath;
+      const newReq = new Request(newUrl.toString(), req);
+      return stub.fetch(newReq);
+    }
+    if (url.pathname.startsWith("/api/projects")) {
+      return handleProjects(req, env);
+    }
+    if (url.pathname === "/mcp" && req.method === "POST") {
+      return handleMCP(req);
+    }
+    return new Response("Not found", { status: 404 });
+  },
 };

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,0 +1,27 @@
+export interface MCPRequest {
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+export async function handleMCP(request: Request): Promise<Response> {
+  try {
+    const payload = (await request.json()) as MCPRequest;
+    switch (payload.method) {
+      case "ping":
+        return json({ result: "pong" });
+      case "listTools":
+        return json({ tools: ["ping"] });
+      default:
+        return json({ error: `Unknown method: ${payload.method}` }, 400);
+    }
+  } catch {
+    return json({ error: "Invalid MCP request" }, 400);
+  }
+}
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/src/routes/projects.ts
+++ b/src/routes/projects.ts
@@ -1,0 +1,62 @@
+import type { D1Database } from "@cloudflare/workers-types";
+import { DatabaseService } from "../services/DatabaseService";
+
+interface Env {
+  AI_COLLABORATION_DB: D1Database;
+}
+
+/**
+ * Handles CRUD operations for `/api/projects` endpoints backed by the D1
+ * database.
+ *
+ * Routes:
+ * - `GET /api/projects` – list all projects.
+ * - `POST /api/projects` – create a project. Body: `{ name: string, description?, status? }`.
+ * - `GET /api/projects/{id}` – retrieve a project by ID.
+ * - `PUT /api/projects/{id}` – update project fields with JSON body.
+ * - `DELETE /api/projects/{id}` – remove the project.
+ */
+export async function handleProjects(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  const db = new DatabaseService(env.AI_COLLABORATION_DB);
+  const url = new URL(request.url);
+  const id = url.pathname.split("/")[3]; // /api/projects/:id
+
+  try {
+    if (request.method === "GET" && !id) {
+      const projects = await db.listProjects();
+      return Response.json(projects);
+    }
+    if (request.method === "POST" && !id) {
+      const body = await request.json();
+      const project = await db.createProject(body);
+      return new Response(JSON.stringify(project), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (request.method === "GET" && id) {
+      const project = await db.getProject(id);
+      if (!project) return new Response("Not found", { status: 404 });
+      return Response.json(project);
+    }
+    if (request.method === "PUT" && id) {
+      const body = await request.json();
+      const project = await db.updateProject(id, body);
+      if (!project) return new Response("Not found", { status: 404 });
+      return new Response(JSON.stringify(project), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (request.method === "DELETE" && id) {
+      await db.deleteProject(id);
+      return new Response(null, { status: 204 });
+    }
+    return new Response("Not found", { status: 404 });
+  } catch (err) {
+    return new Response((err as Error).message, { status: 500 });
+  }
+}

--- a/src/services/DatabaseService.ts
+++ b/src/services/DatabaseService.ts
@@ -1,0 +1,80 @@
+import type { D1Database } from "@cloudflare/workers-types";
+import type { Project } from "../types/Project";
+
+interface DBProject {
+  id: string;
+  name: string;
+  description: string | null;
+  status: Project["status"];
+  created_at: number;
+  updated_at: number;
+}
+
+function mapProject(row: DBProject): Project {
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description ?? "",
+    status: row.status ?? "planning",
+    createdAt: row.created_at * 1000,
+    updatedAt: row.updated_at * 1000,
+  };
+}
+
+export class DatabaseService {
+  constructor(private db: D1Database) {}
+
+  async listProjects(): Promise<Project[]> {
+    const { results } = await this.db
+      .prepare(
+        "SELECT id, name, description, status, created_at, updated_at FROM projects",
+      )
+      .all<DBProject>();
+    return (results ?? []).map(mapProject);
+  }
+
+  async getProject(id: string): Promise<Project | null> {
+    const { results } = await this.db
+      .prepare(
+        "SELECT id, name, description, status, created_at, updated_at FROM projects WHERE id=?1",
+      )
+      .bind(id)
+      .all<DBProject>();
+    return results && results[0] ? mapProject(results[0]) : null;
+  }
+
+  async createProject(data: {
+    id?: string;
+    name: string;
+    description?: string;
+    status?: Project["status"];
+  }): Promise<Project> {
+    const id = data.id ?? crypto.randomUUID();
+    await this.db
+      .prepare(
+        "INSERT INTO projects (id, name, description, status, created_at, updated_at) VALUES (?1, ?2, ?3, IFNULL(?4,'planning'), unixepoch(), unixepoch())",
+      )
+      .bind(id, data.name, data.description ?? null, data.status ?? null)
+      .run();
+    const project = await this.getProject(id);
+    if (!project) throw new Error("Failed to load created project");
+    return project;
+  }
+
+  async updateProject(
+    id: string,
+    data: { name?: string; description?: string; status?: Project["status"] },
+  ): Promise<Project | null> {
+    await this.db
+      .prepare(
+        "UPDATE projects SET name=IFNULL(?2,name), description=IFNULL(?3,description), status=IFNULL(?4,status), updated_at=unixepoch() WHERE id=?1",
+      )
+      .bind(id, data.name ?? null, data.description ?? null, data.status ?? null)
+      .run();
+    return await this.getProject(id);
+  }
+
+  async deleteProject(id: string): Promise<void> {
+    await this.db.prepare("DELETE FROM projects WHERE id=?1").bind(id).run();
+  }
+}

--- a/src/types/Project.ts
+++ b/src/types/Project.ts
@@ -1,0 +1,15 @@
+export type ProjectStatus =
+  | "planning"
+  | "active"
+  | "paused"
+  | "completed"
+  | "archived";
+
+export interface Project {
+  id: string;
+  name: string;
+  description?: string;
+  status: ProjectStatus;
+  createdAt: number;
+  updatedAt: number;
+}

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1,7 +1,83 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+vi.mock('cloudflare:workers', () => ({
+  DurableObject: class {},
+  WorkflowEntrypoint: class {},
+  WorkflowEvent: class {},
+  WorkflowStep: class {},
+  WorkflowNamespace: class {}
+}));
 import worker from '../src/index';
-import { describe, it, expect } from 'vitest';
+import { ProjectCoordinator } from '../src/durable-objects/ProjectCoordinator';
 
-const env = {} as any;
+class D1Stub {
+  projects = new Map<string, any>();
+  prepare(query: string) {
+    const self = this;
+    const q = query.trim().toUpperCase();
+    const exec = (params: any[]) => ({
+      async run() {
+        if (q.startsWith('INSERT')) {
+          self.projects.set(params[0], {
+            id: params[0],
+            name: params[1],
+            description: params[2],
+            status: params[3] ?? 'planning',
+            created_at: Math.floor(Date.now() / 1000),
+            updated_at: Math.floor(Date.now() / 1000),
+          });
+        } else if (q.startsWith('UPDATE')) {
+          const p = self.projects.get(params[0]);
+          if (p) {
+            if (params[1] !== null) p.name = params[1];
+            if (params[2] !== null) p.description = params[2];
+            if (params[3] !== null) p.status = params[3];
+            p.updated_at = Math.floor(Date.now() / 1000);
+          }
+        } else if (q.startsWith('DELETE')) {
+          self.projects.delete(params[0]);
+        }
+        return { success: true } as any;
+      },
+      async all<T>() {
+        if (q.includes('WHERE')) {
+          const proj = self.projects.get(params[0]);
+          return { results: proj ? [proj as T] : [] } as any;
+        }
+        return { results: Array.from(self.projects.values()) as T[] } as any;
+      },
+    });
+    return {
+      bind(...params: any[]) {
+        return exec(params);
+      },
+      all<T>() {
+        return exec([]).all<T>();
+      },
+    };
+  }
+}
+
+let env: any;
+let doStubFetch: any;
+beforeEach(() => {
+  doStubFetch = vi.fn(async (req: Request) =>
+    new Response(
+      JSON.stringify({
+        path: new URL(req.url).pathname,
+        method: req.method,
+        search: new URL(req.url).search,
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    ),
+  );
+  env = {
+    AI_COLLABORATION_DB: new D1Stub(),
+    PROJECT_COORDINATOR: {
+      idFromName: vi.fn(() => 'id'),
+      get: vi.fn(() => ({ fetch: doStubFetch })),
+    },
+  };
+});
 
 describe('worker', () => {
   it('returns ok on /health', async () => {
@@ -17,5 +93,186 @@ describe('worker', () => {
     const data = await res.json();
     expect(typeof data.uptime).toBe('number');
     expect(data.uptime).toBeGreaterThanOrEqual(0);
+  });
+
+  it('responds to MCP ping', async () => {
+    const res = await worker.fetch(
+      new Request('http://localhost/mcp', {
+        method: 'POST',
+        body: JSON.stringify({ method: 'ping' })
+      }),
+      env
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.result).toBe('pong');
+  });
+
+  it('creates, lists, and updates projects with timestamps', async () => {
+    const create = await worker.fetch(
+      new Request('http://localhost/api/projects', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'test project' })
+      }),
+      env
+    );
+    expect(create.status).toBe(201);
+    const created = await create.json();
+    expect(typeof created.createdAt).toBe('number');
+    expect(created.createdAt).toBe(created.updatedAt);
+    expect(created.status).toBe('planning');
+
+    const list = await worker.fetch(new Request('http://localhost/api/projects'), env);
+    const projects = await list.json();
+    expect(projects.length).toBe(1);
+    expect(projects[0].createdAt).toBe(created.createdAt);
+    expect(projects[0].status).toBe('planning');
+
+    const update = await worker.fetch(
+      new Request(`http://localhost/api/projects/${created.id}`, {
+        method: 'PUT',
+        body: JSON.stringify({ status: 'active' })
+      }),
+      env
+    );
+    expect(update.status).toBe(200);
+    const updated = await update.json();
+    expect(updated.status).toBe('active');
+    expect(updated.updatedAt).toBeGreaterThanOrEqual(created.updatedAt);
+  });
+
+  it('forwards agent operations to the ProjectCoordinator DO', async () => {
+    const res = await worker.fetch(
+      new Request('http://localhost/api/projects/123/agents', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'Agent 1' }),
+      }),
+      env,
+    );
+    expect(doStubFetch).toHaveBeenCalledOnce();
+    const body = await res.json();
+    expect(body.path).toBe('/agents');
+    expect(body.method).toBe('POST');
+  });
+
+  it('forwards query strings to the ProjectCoordinator DO', async () => {
+    const res = await worker.fetch(
+      new Request('http://localhost/api/projects/123/tasks?status=todo&tags=foo,bar'),
+      env,
+    );
+    expect(doStubFetch).toHaveBeenCalledOnce();
+    const body = await res.json();
+    expect(body.path).toBe('/tasks');
+    expect(body.search).toBe('?status=todo&tags=foo,bar');
+  });
+
+  it('forwards additional subpaths like context, analytics, and initialize', async () => {
+    let res = await worker.fetch(
+      new Request('http://localhost/api/projects/123/context', {
+        method: 'PUT',
+        body: JSON.stringify({ foo: 'bar' })
+      }),
+      env,
+    );
+    expect(doStubFetch).toHaveBeenCalledOnce();
+    let body = await res.json();
+    expect(body.path).toBe('/context');
+    expect(body.method).toBe('PUT');
+
+    res = await worker.fetch(
+      new Request('http://localhost/api/projects/123/analytics'),
+      env,
+    );
+    expect(doStubFetch).toHaveBeenCalledTimes(2);
+    body = await res.json();
+    expect(body.path).toBe('/analytics');
+    expect(body.method).toBe('GET');
+
+    res = await worker.fetch(
+      new Request('http://localhost/api/projects/123/initialize', {
+        method: 'POST',
+        body: JSON.stringify({})
+      }),
+      env,
+    );
+    expect(doStubFetch).toHaveBeenCalledTimes(3);
+    body = await res.json();
+    expect(body.path).toBe('/initialize');
+    expect(body.method).toBe('POST');
+  });
+});
+
+describe('ProjectCoordinator filtering', () => {
+  const createDO = () => {
+    const storage = new Map<string, any>();
+    const state: any = {
+      storage: {
+        get: async (key: string) => storage.get(key),
+        put: async (key: string, value: any) => {
+          storage.set(key, value);
+        },
+      },
+      blockConcurrencyWhile: async (fn: () => any) => {
+        await fn();
+      },
+    };
+    return new ProjectCoordinator(state, {} as any);
+  };
+
+  it('limits and filters messages', async () => {
+    const pc = createDO();
+    await pc.fetch(
+      new Request('http://do/messages', {
+        method: 'POST',
+        body: JSON.stringify({ agentId: 'a1', type: 'chat', content: 'hello' }),
+      }),
+    );
+    await pc.fetch(
+      new Request('http://do/messages', {
+        method: 'POST',
+        body: JSON.stringify({ agentId: 'a2', type: 'status', content: 'ok' }),
+      }),
+    );
+    await pc.fetch(
+      new Request('http://do/messages', {
+        method: 'POST',
+        body: JSON.stringify({ agentId: 'a3', type: 'chat', content: 'bye' }),
+      }),
+    );
+    const res = await pc.fetch(
+      new Request('http://do/messages?limit=1&type=chat'),
+    );
+    const messages = await res.json();
+    expect(messages.length).toBe(1);
+    expect(messages[0].content).toBe('bye');
+  });
+
+  it('filters tasks by tags and status', async () => {
+    const pc = createDO();
+    await pc.fetch(
+      new Request('http://do/tasks', {
+        method: 'POST',
+        body: JSON.stringify({ title: 't1', tags: ['foo'], status: 'todo' }),
+      }),
+    );
+    await pc.fetch(
+      new Request('http://do/tasks', {
+        method: 'POST',
+        body: JSON.stringify({ title: 't2', tags: ['bar'], status: 'in-progress' }),
+      }),
+    );
+    await pc.fetch(
+      new Request('http://do/tasks', {
+        method: 'POST',
+        body: JSON.stringify({ title: 't3', tags: ['foo', 'baz'], status: 'todo' }),
+      }),
+    );
+    const res = await pc.fetch(
+      new Request('http://do/tasks?tags=foo,bar&status=todo'),
+    );
+    const tasks = await res.json();
+    expect(tasks.length).toBe(2);
+    const titles = tasks.map((t: any) => t.title).sort();
+    expect(titles).toEqual(['t1', 't3']);
   });
 });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -17,9 +17,22 @@ class_name = "WorkFlowLive"
 name = "WEBSOCKET_DO"
 class_name = "WebSocketDO"
 
+[[durable_objects.bindings]]
+name = "PROJECT_COORDINATOR"
+class_name = "ProjectCoordinator"
+
 [[migrations]]
 tag = "v1"
 new_classes = ["WebSocketDO"]
+
+[[migrations]]
+tag = "v2"
+new_classes = ["ProjectCoordinator"]
+
+[[d1_databases]]
+binding = "AI_COLLABORATION_DB"
+database_name = "ai-collaboration-db"
+database_id = "ai-collaboration-db"
 
 [assets]
 directory = "src/static"


### PR DESCRIPTION
## Summary
- add `status` column to projects schema and expose matching ProjectStatus type
- map snake_case DB columns to camelCase API fields with reliable timestamp conversion
- return updated project records from CRUD routes and extend tests for timestamp and status handling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897f6de1730832ea855967fa76ac4d3