### PR TITLE
feat: enforce foreign keys and add migrations

### DIFF
--- a/schemas/migrations/002_add_fk_cascade.sql
+++ b/schemas/migrations/002_add_fk_cascade.sql
@@ -1,0 +1,50 @@
+BEGIN TRANSACTION;
+PRAGMA foreign_keys=OFF;
+
+-- Create new tables with FK constraints
+CREATE TABLE projects_new (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  description TEXT,
+  status TEXT DEFAULT 'planning',
+  created_at INTEGER DEFAULT (strftime('%s','now')),
+  updated_at INTEGER DEFAULT (strftime('%s','now'))
+);
+CREATE TABLE agents_new (
+  id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  role TEXT,
+  created_at INTEGER DEFAULT (strftime('%s','now')),
+  updated_at INTEGER DEFAULT (strftime('%s','now')),
+  FOREIGN KEY(project_id) REFERENCES projects(id) ON DELETE CASCADE
+);
+CREATE TABLE tasks_new (
+  id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  status TEXT,
+  created_at INTEGER DEFAULT (strftime('%s','now')),
+  updated_at INTEGER DEFAULT (strftime('%s','now')),
+  FOREIGN KEY(project_id) REFERENCES projects(id) ON DELETE CASCADE
+);
+
+-- Copy data
+INSERT INTO projects_new SELECT * FROM projects;
+INSERT INTO agents_new   SELECT * FROM agents;
+INSERT INTO tasks_new    SELECT * FROM tasks;
+
+-- Swap
+ALTER TABLE projects RENAME TO projects_old;
+ALTER TABLE projects_new RENAME TO projects;
+ALTER TABLE agents RENAME TO agents_old;
+ALTER TABLE agents_new RENAME TO agents;
+ALTER TABLE tasks RENAME TO tasks_old;
+ALTER TABLE tasks_new RENAME TO tasks;
+
+DROP TABLE projects_old;
+DROP TABLE agents_old;
+DROP TABLE tasks_old;
+
+PRAGMA foreign_keys=ON;
+COMMIT;

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,8 +190,9 @@ app.get('/api/workflow/:id', async (c: Context<{ Bindings: Env }>) => {
 
 /**
  * Routes for the ProjectCoordinator Durable Object from the codex branch.
+ * Use `app.all` so that any HTTP method is proxied through to the DO.
  */
-app.get('/api/projects/:id/:subpath{.*}', async (c: Context<{ Bindings: Env }>) => {
+app.all('/api/projects/:id/:subpath{.*}', async (c: Context<{ Bindings: Env }>) => {
   const id = c.req.param('id');
   const subPath = c.req.param('subpath');
   const stub = c.env.PROJECT_COORDINATOR.get(

--- a/src/services/DatabaseService.ts
+++ b/src/services/DatabaseService.ts
@@ -22,7 +22,16 @@ function mapProject(row: DBProject): Project {
 }
 
 export class DatabaseService {
-  constructor(private db: D1Database) {}
+  private constructor(private db: D1Database) {}
+
+  /**
+   * Create a new DatabaseService and enable foreign key enforcement on the
+   * connection. Call this instead of `new DatabaseService()`.
+   */
+  static async create(db: D1Database): Promise<DatabaseService> {
+    await db.prepare('PRAGMA foreign_keys=ON').run();
+    return new DatabaseService(db);
+  }
 
   async listProjects(): Promise<Project[]> {
     const { results } = await this.db
@@ -65,16 +74,36 @@ export class DatabaseService {
     id: string,
     data: { name?: string; description?: string; status?: Project["status"] },
   ): Promise<Project | null> {
+    if (
+      data.status &&
+      !["planning", "active", "paused", "completed", "archived"].includes(data.status)
+    ) {
+      throw new Error("Invalid status");
+    }
+    const start = Date.now();
+    await this.db
+      .prepare(
+        "EXPLAIN QUERY PLAN UPDATE projects SET name=IFNULL(?2,name), description=IFNULL(?3,description), status=IFNULL(?4,status), updated_at=unixepoch() WHERE id=?1",
+      )
+      .bind(id, data.name ?? null, data.description ?? null, data.status ?? null)
+      .all();
     await this.db
       .prepare(
         "UPDATE projects SET name=IFNULL(?2,name), description=IFNULL(?3,description), status=IFNULL(?4,status), updated_at=unixepoch() WHERE id=?1",
       )
       .bind(id, data.name ?? null, data.description ?? null, data.status ?? null)
       .run();
+    console.log("updateProject took", Date.now() - start, "ms");
     return await this.getProject(id);
   }
 
   async deleteProject(id: string): Promise<void> {
+    const start = Date.now();
+    await this.db
+      .prepare("EXPLAIN QUERY PLAN DELETE FROM projects WHERE id=?1")
+      .bind(id)
+      .all();
     await this.db.prepare("DELETE FROM projects WHERE id=?1").bind(id).run();
+    console.log("deleteProject took", Date.now() - start, "ms");
   }
 }

--- a/src/services/migrations.ts
+++ b/src/services/migrations.ts
@@ -1,0 +1,39 @@
+import type { D1Database } from '@cloudflare/workers-types';
+import sql002 from '../../schemas/migrations/002_add_fk_cascade.sql?raw';
+
+interface Migration {
+  id: string;
+  sql: string;
+}
+
+const MIGRATIONS: Migration[] = [
+  { id: '002_add_fk_cascade', sql: sql002 },
+];
+
+/**
+ * Run pending SQL migrations. Each migration is executed once and tracked in
+ * the `__migrations` table.
+ */
+export async function runMigrations(db: D1Database): Promise<void> {
+  await db
+    .prepare('CREATE TABLE IF NOT EXISTS __migrations (id TEXT PRIMARY KEY)')
+    .run();
+  const { results } = await db
+    .prepare('SELECT id FROM __migrations')
+    .all<{ id: string }>();
+  const done = new Set(results?.map((r) => r.id));
+  for (const m of MIGRATIONS) {
+    if (done.has(m.id)) continue;
+    const statements = m.sql
+      .split(';')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    for (const s of statements) {
+      await db.prepare(s).run();
+    }
+    await db
+      .prepare('INSERT INTO __migrations (id) VALUES (?1)')
+      .bind(m.id)
+      .run();
+  }
+}


### PR DESCRIPTION
## Summary
- enable method-agnostic routing for ProjectCoordinator DO
- ensure D1 connections enforce foreign keys and track performance
- add migration runner with FK cascade migration

## Testing
- `npm test` *(fails: expected 201 but received 404)*

------
https://chatgpt.com/codex/tasks/task_e_68997bbd99d0832e9ed1d73fc44ac584